### PR TITLE
Bumped rspec-rails to 4.0.0.beta2, which has the  EmptyTemplateHandle…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'webpacker', '~> 4.0'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw] unless ENV['RM_INFO']
-  gem 'rspec-rails'
+  gem 'rspec-rails', '4.0.0.beta2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,14 +167,14 @@ GEM
     rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-rails (3.8.2)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-      rspec-support (~> 3.8.0)
+    rspec-rails (4.0.0.beta2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.8)
+      rspec-expectations (~> 3.8)
+      rspec-mocks (~> 3.8)
+      rspec-support (~> 3.8)
     rspec-support (3.8.2)
     rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
@@ -257,7 +257,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.1.9)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby
@@ -274,7 +274,7 @@ DEPENDENCIES
   public_suffix (~> 3.0.1)
   puma (~> 4.0)
   rails (~> 6.0.0)
-  rspec-rails
+  rspec-rails (= 4.0.0.beta2)
   rubocop
   rubocop-performance
   rubocop-rails


### PR DESCRIPTION
…r arguments fixed - https://github.com/rspec/rspec-rails/pull/2089

Bumped zeitwerk as well.