### PR TITLE
Revert "Bump parallel from 1.20.1 to 1.20.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       racc (~> 1.4)
     oj (3.13.2)
     pagy (4.11.0)
-    parallel (1.20.2)
+    parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)


### PR DESCRIPTION
Reverts texpert/rails_6_rss_reader#323 - see https://github.com/grosser/parallel/pull/301