### PR TITLE
Revert "Bump shakapacker from 6.5.2 to 6.5.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rails-erb-loader": "github:usabilityhub/rails-erb-loader",
     "sass": "^1.55.0",
     "sass-loader": "^13.1.0",
-    "shakapacker": "6.5.3",
+    "shakapacker": "6.5.2",
     "terser-webpack-plugin": "5",
     "turbolinks": "^5.2.0",
     "uppy": "2.13.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,10 +4375,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.5.3.tgz#4ac2902dae1c6531b4f5f63ce0fa9319cf5cc232"
-  integrity sha512-PtEuP2drIl8RjkWtC6S2iTMJ8IDadIG0HijyVArCD6jUDzpGWA0gtnWGr/pvmGbvg3MPS6kF5RFVOz1YDUvxJw==
+shakapacker@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.5.2.tgz#dda95543107a71c7ada3f6ee102a1a31563c6738"
+  integrity sha512-32hpr/AuyQJEk/4J8quL/xLPl+NPR0mBvJ3D9AtwHIkbSTUA0++LZrvVO+aQ4S1Uy3Iz2KSI/JVRGGD/C4SFFg==
   dependencies:
     glob "^7.2.0"
     js-yaml "^4.1.0"


### PR DESCRIPTION
Reverts texpert/rails_6_rss_reader#1482 because of a breaking change, introduced in mini-css--extract-plugin#chunkfilename - see https://github.com/shakacode/shakapacker/issues/198