### PR TITLE
Revert "Bump selenium-webdriver from 4.9.0 to 4.9.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       sprockets-rails
       tilt
     sax-machine (1.3.2)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
Reverts texpert/rails_6_rss_reader#2272 because 4.9.1 is requiring Ruby 3.0
